### PR TITLE
インクリメンタルサーチの実装

### DIFF
--- a/app/assets/javascripts/users.js
+++ b/app/assets/javascripts/users.js
@@ -29,7 +29,6 @@ $(function() {
 
   function addMemberToDB(userId) {
     let html = `<input value="${userId}" name="group[user_ids][]" type="hidden" id="group_user_ids_${userId}" />`;
-    console.log(html);
     $(`#${userId}`).append(html);
   }
 

--- a/app/assets/javascripts/users.js
+++ b/app/assets/javascripts/users.js
@@ -42,4 +42,9 @@ $(function() {
       alert("ユーザー検索に失敗しました");
     });
   });
+
+  $(document).on('click', ".chat-group-user__btn--add", function() {
+    $(this).parent().remove();
+  });
+  
 });

--- a/app/assets/javascripts/users.js
+++ b/app/assets/javascripts/users.js
@@ -59,4 +59,8 @@ $(function() {
     appendUserToList(userName, userId);
   });
   
+  $(document).on('click', ".chat-group-user__btn--remove", function() {
+    $(this).parent().remove();
+  });
+  
 });

--- a/app/assets/javascripts/users.js
+++ b/app/assets/javascripts/users.js
@@ -18,6 +18,15 @@ $(function() {
     $('#user-search-result').append(html);
 }
 
+  function appendUserToList(userName, userId) {
+    let html = `
+    <div class="chat-group-user clearfix" id="${userId}">
+      <p class="chat-group-user__name">${userName}</p>
+      <div class="user-search-remove chat-group-user__btn chat-group-user__btn--remove js-remove-btn" data-user-id="${userId}" data-user-name="${userName}">削除</div>
+    </div>`;
+    $(".js-add-user").append(html);
+  }
+
   $("#user-search-field").on("keyup", function() {
     let input = $(this).val();
     $.ajax({
@@ -45,6 +54,9 @@ $(function() {
 
   $(document).on('click', ".chat-group-user__btn--add", function() {
     $(this).parent().remove();
+    let userName = $(this).attr("data-user-name");
+    let userId = $(this).attr("data-user-id");
+    appendUserToList(userName, userId);
   });
   
 });

--- a/app/assets/javascripts/users.js
+++ b/app/assets/javascripts/users.js
@@ -1,6 +1,6 @@
 $(function() {
 
-  function  appendUser(user){
+  function  appendUserToSearchResult(user){
     let html = `
               <div class="chat-group-user clearfix">
                 <p class="chat-group-user__name"> ${user.name} </p>
@@ -10,7 +10,7 @@ $(function() {
     $('#user-search-result').append(html);
   }
 
-  function  appendErrMsg(msg){
+  function  appendErrMsgToSearchResult(msg){
     let html = `
                <div class="chat-group-user clearfix">
                 <p class="chat-group-user__name"> ${msg} </p>
@@ -39,12 +39,12 @@ $(function() {
       $('#user-search-result').empty();
       if (users.length !== 0) {
         users.forEach(function(user){
-          appendUser(user);
+          appendUserToSearchResult(user);
         });
       } else if (input.length === 0) {
         return false;
       } else {
-        appendErrMsg("ユーザーが見つかりません");
+        appendErrMsgToSearchResult("ユーザーが見つかりません");
       }
     })
     .fail(function() {

--- a/app/assets/javascripts/users.js
+++ b/app/assets/javascripts/users.js
@@ -1,4 +1,23 @@
 $(function() {
+
+  function  appendUser(user){
+    let html = `
+              <div class="chat-group-user clearfix">
+                <p class="chat-group-user__name"> ${user.name} </p>
+                <div class="user-search-add chat-group-user__btn chat-group-user__btn--add" data-user-id="${user.id}" data-user-name= "${user.name}">追加</div>
+              </div>
+              `;
+    $('#user-search-result').append(html);
+  }
+
+  function  appendErrMsg(msg){
+    let html = `
+               <div class="chat-group-user clearfix">
+                <p class="chat-group-user__name"> ${msg} </p>
+               </div>`;
+    $('#user-search-result').append(html);
+}
+
   $("#user-search-field").on("keyup", function() {
     let input = $(this).val();
     $.ajax({
@@ -8,8 +27,19 @@ $(function() {
       dataType: "json"
     })
     .done(function(users) {
+      $('#user-search-result').empty();
+      if (users.length !== 0) {
+        users.forEach(function(user){
+          appendUser(user);
+        });
+      } else if (input.length === 0) {
+        return false;
+      } else {
+        appendErrMsg("ユーザーが見つかりません");
+      }
     })
     .fail(function() {
+      alert("ユーザー検索に失敗しました");
     });
   });
 });

--- a/app/assets/javascripts/users.js
+++ b/app/assets/javascripts/users.js
@@ -1,0 +1,5 @@
+$(function() {
+  $("#user-search-field").on("keyup", function() {
+    let input = $(this).val();
+  });
+});

--- a/app/assets/javascripts/users.js
+++ b/app/assets/javascripts/users.js
@@ -1,5 +1,15 @@
 $(function() {
   $("#user-search-field").on("keyup", function() {
     let input = $(this).val();
+    $.ajax({
+      type: "GET",
+      url: "/users",
+      data: { keyword: input },
+      dataType: "json"
+    })
+    .done(function(users) {
+    })
+    .fail(function() {
+    });
   });
 });

--- a/app/assets/javascripts/users.js
+++ b/app/assets/javascripts/users.js
@@ -27,6 +27,12 @@ $(function() {
     $(".js-add-user").append(html);
   }
 
+  function addMemberToDB(userId) {
+    let html = `<input value="${userId}" name="group[user_ids][]" type="hidden" id="group_user_ids_${userId}" />`;
+    console.log(html);
+    $(`#${userId}`).append(html);
+  }
+
   $("#user-search-field").on("keyup", function() {
     let input = $(this).val();
     $.ajax({
@@ -57,6 +63,7 @@ $(function() {
     let userName = $(this).attr("data-user-name");
     let userId = $(this).attr("data-user-id");
     appendUserToList(userName, userId);
+    addMemberToDB(userId)
   });
   
   $(document).on('click', ".chat-group-user__btn--remove", function() {

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,5 +1,8 @@
 class UsersController < ApplicationController
 
+  def index
+  end
+  
   def edit
   end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,6 +1,10 @@
 class UsersController < ApplicationController
 
   def index
+    respond_to do |format|
+      format.html
+      format.json
+    end
   end
   
   def edit

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -3,7 +3,6 @@ class UsersController < ApplicationController
   def index
     @users = User.search(params[:keyword], current_user.id)
     respond_to do |format|
-      format.html
       format.json
     end
   end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,12 +1,13 @@
 class UsersController < ApplicationController
 
   def index
+    @users = User.search(params[:keyword], current_user.id)
     respond_to do |format|
       format.html
       format.json
     end
   end
-  
+
   def edit
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,4 +8,13 @@ class User < ApplicationRecord
   has_many :groups, through: :group_users
   has_many :messages
   validates :name, presence: true, uniqueness: true
+
+  def self.search(input, id)
+    if input == ""
+      return nil
+    else
+      User.where('name LIKE(?)', "%#{input}%").where.not(id: id)
+    end
+  end
+
 end

--- a/app/views/groups/_form.html.haml
+++ b/app/views/groups/_form.html.haml
@@ -10,15 +10,20 @@
       = f.label :name, class: 'chat-group-form__label'
     .chat-group-form__field--right
       = f.text_field :name, class: 'chat__group_name chat-group-form__input', placeholder: 'グループ名を入力してください'
-  .chat-group-form__field.clearfix
-    / この部分はインクリメンタルサーチ（ユーザー追加の非同期化のときに使用します
+  .chat-group-form__field
+    .chat-group-form__field--left
+      %label.chat-group-form__label{:for => "chat_group_チャットメンバーを追加"} チャットメンバーを追加
+    .chat-group-form__field--right
+      .chat-group-form__search.clearfix
+        %input#user-search-field.chat-group-form__input{:placeholder => "追加したいユーザー名を入力してください", :type => "text"}/
+      #user-search-result
+
   .chat-group-form__field.clearfix
     .chat-group-form__field--left
       %label.chat-group-form__label{:for => "chat_group_チャットメンバー"} チャットメンバー
     .chat-group-form__field--right
-      / グループ作成機能の追加時はここにcollection_check_boxesの記述を入れてください
-      = f.collection_check_boxes :user_ids, User.all, :id, :name
-      / この部分はインクリメンタルサーチ（ユーザー追加の非同期化のときに使用します
+      #chat-group-users.js-add-user
+
   .chat-group-form__field.clearfix
     .chat-group-form__field--left
     .chat-group-form__field--right

--- a/app/views/groups/_form.html.haml
+++ b/app/views/groups/_form.html.haml
@@ -26,6 +26,14 @@
         .chat-group-user.clearfix.js-chat-member
           %input{name: "group[user_ids][]", type: "hidden", value: current_user.id}
           %p.chat-group-user__name= current_user.name
+        - group.users.each do |user|
+          - if current_user.name != user.name
+            .chat-group-user.clearfix.js-chat-member
+              %input{name: "group[user_ids][]", type: "hidden", value: user.id}
+              %p.chat-group-user__name
+                = user.name 
+              %a.user-search-remove.chat-group-user__btn.chat-group-user__btn--remove.js-remove-btn
+                削除
 
   .chat-group-form__field.clearfix
     .chat-group-form__field--left

--- a/app/views/groups/_form.html.haml
+++ b/app/views/groups/_form.html.haml
@@ -10,7 +10,7 @@
       = f.label :name, class: 'chat-group-form__label'
     .chat-group-form__field--right
       = f.text_field :name, class: 'chat__group_name chat-group-form__input', placeholder: 'グループ名を入力してください'
-  .chat-group-form__field
+  .chat-group-form__field.clearfix
     .chat-group-form__field--left
       %label.chat-group-form__label{:for => "chat_group_チャットメンバーを追加"} チャットメンバーを追加
     .chat-group-form__field--right
@@ -23,6 +23,9 @@
       %label.chat-group-form__label{:for => "chat_group_チャットメンバー"} チャットメンバー
     .chat-group-form__field--right
       #chat-group-users.js-add-user
+        .chat-group-user.clearfix.js-chat-member
+          %input{name: "group[user_ids][]", type: "hidden", value: current_user.id}
+          %p.chat-group-user__name= current_user.name
 
   .chat-group-form__field.clearfix
     .chat-group-form__field--left

--- a/app/views/users/index.json.jbuilder
+++ b/app/views/users/index.json.jbuilder
@@ -1,0 +1,4 @@
+json.array! @users do |user|
+  json.id  user.id
+  json.name  user.name
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,7 @@
 Rails.application.routes.draw do
   devise_for :users
   root 'groups#index'
-  resources :users, only: [:edit, :update]
+  resources :users, only: [:index, :edit, :update]
   resources :groups, only: [:new, :create, :edit, :update] do
     resources :messages, only: [:index, :create]
   end


### PR DESCRIPTION
# What
Chat-spaceのグループ新規作成、および編集画面にてインクリメンタルサーチ機能を追加した。
・サーチ結果をリスト表示し、追加ボタン押下でチャットメンバー欄に移動させる。
・チャットメンバー欄に表示されたメンバーは削除ボタンで削除できる。
・Submit押下により、チャットメンバー欄に表示されたメンバーでグループ作成・更新。
・ログイン中のユーザーはデフォルトでチャットメンバーに設定。
・ログイン中のユーザーはチャットメンバー欄からの削除も不可。
（※）チャットメンバー欄に追加済みのメンバー（ログイン中のユーザー以外）について、再検索時は検索結果の表示対象外とする機能については未実装。そのため現時点では同一グループ内にメンバーが重複し得る仕様となっている。

# Why
利便性の向上のため。
![e57638c8751ee36a96e2022a49cf720b](https://user-images.githubusercontent.com/63938372/82394626-7eaf4e00-9a84-11ea-82d3-694963e6c4f2.gif)
![3eed6226d94fd224600b163123587cab](https://user-images.githubusercontent.com/63938372/82394629-8242d500-9a84-11ea-9942-f57d7ad213f1.gif)

