### PR TITLE
メッセージの自動更新機能の実装

### DIFF
--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -1,4 +1,7 @@
 $(function(){
+  var reloadMessages = function() {
+  };
+
   function buildHTML(message) {
     if (message.content && message.image) {
       var html =
@@ -79,4 +82,5 @@ $(function(){
       $('.send-btn').prop('disabled', false);
     });
   })
+  setInterval(reloadMessages, 7000);
 })

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -1,5 +1,20 @@
 $(function(){
+
   var reloadMessages = function() {
+    let last_message_id = $('.message-items:last').data("message-id");
+    $.ajax({
+      url: './api/messages',
+      type: 'get',
+      dataType: 'json',
+      data: {id: last_message_id}
+    })
+    .done(function(messages) {
+      console.log("success");
+    })
+    .fail(function() {
+      console.log("error");
+    });
+    
   };
 
   function buildHTML(message) {
@@ -82,5 +97,5 @@ $(function(){
       $('.send-btn').prop('disabled', false);
     });
   })
-  setInterval(reloadMessages, 7000);
+  reloadMessages();
 })

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -104,5 +104,9 @@ $(function(){
       $('.send-btn').prop('disabled', false);
     });
   })
-  reloadMessages();
+  
+  if (document.location.href.match(/\/groups\/\d+\/messages/)) {
+    setInterval(reloadMessages, 7000);
+  }
+
 })

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -9,10 +9,15 @@ $(function(){
       data: {id: last_message_id}
     })
     .done(function(messages) {
+      var insertHTML = '';
+      $.each(messages, function(i, message) {
+        insertHTML += buildHTML(message)
+      });
+      $('.messages').append(insertHTML);
       console.log("success");
     })
     .fail(function() {
-      console.log("error");
+      alert('error');
     });
     
   };

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -14,8 +14,8 @@ $(function(){
         $.each(messages, function(i, message) {
           insertHTML += buildHTML(message)
         });
-        $('.messages').append(insertHTML);
-        $('.messages').animate({ scrollTop: $('.messages')[0].scrollHeight});
+        $('.chat-main').find('.main').append(insertHTML);
+        $('.chat-main').find('.main').animate({ scrollTop: $('.chat-main').find('.main')[0].scrollHeight});
       }
     })
     .fail(function() {

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -9,12 +9,14 @@ $(function(){
       data: {id: last_message_id}
     })
     .done(function(messages) {
-      var insertHTML = '';
-      $.each(messages, function(i, message) {
-        insertHTML += buildHTML(message)
-      });
-      $('.messages').append(insertHTML);
-      console.log("success");
+      if (messages.length !== 0) {
+        var insertHTML = '';
+        $.each(messages, function(i, message) {
+          insertHTML += buildHTML(message)
+        });
+        $('.messages').append(insertHTML);
+        $('.messages').animate({ scrollTop: $('.messages')[0].scrollHeight});
+      }
     })
     .fail(function() {
       alert('error');

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -2,7 +2,7 @@ $(function(){
   function buildHTML(message) {
     if (message.content && message.image) {
       var html =
-        `<div class="message-items">
+        `<div class="message-items" data-message-id=${message.id}>
           <div class="message-items__title">
             <div class="member">
               ${message.member}
@@ -20,7 +20,7 @@ $(function(){
         </div>`
     } else if (message.content) {
       var html =
-        `<div class="message-items">
+        `<div class="message-items" data-message-id=${message.id}>
           <div class="message-items__title">
             <div class="member">
               ${message.member}
@@ -37,7 +37,7 @@ $(function(){
         </div>`
     } else if (message.image) {
       var html =
-        `<div class="message-items">
+        `<div class="message-items" data-message-id=${message.id}>
           <div class="message-items__title">
             <div class="member">
               ${message.member}

--- a/app/controllers/api/messages_controller.rb
+++ b/app/controllers/api/messages_controller.rb
@@ -1,0 +1,4 @@
+class Api::MessagesController < ApplicationController
+  def index
+  end
+end

--- a/app/controllers/api/messages_controller.rb
+++ b/app/controllers/api/messages_controller.rb
@@ -1,10 +1,7 @@
 class Api::MessagesController < ApplicationController
   def index
-    # ルーティングでの設定によりparamsの中にgroup_idというキーでグループのidが入るので、これを元にDBからグループを取得する
     group = Group.find(params[:group_id])
-    # ajaxで送られてくる最後のメッセージのid番号を変数に代入
     last_message_id = params[:id].to_i
-    # 取得したグループでのメッセージ達から、idがlast_message_idよりも新しい(大きい)メッセージ達のみを取得
     @messages = group.messages.includes(:user).where("id > ?", last_message_id)
   end
 end

--- a/app/controllers/api/messages_controller.rb
+++ b/app/controllers/api/messages_controller.rb
@@ -1,4 +1,10 @@
 class Api::MessagesController < ApplicationController
   def index
+    # ルーティングでの設定によりparamsの中にgroup_idというキーでグループのidが入るので、これを元にDBからグループを取得する
+    group = Group.find(params[:group_id])
+    # ajaxで送られてくる最後のメッセージのid番号を変数に代入
+    last_message_id = params[:id].to_i
+    # 取得したグループでのメッセージ達から、idがlast_message_idよりも新しい(大きい)メッセージ達のみを取得
+    @messages = group.messages.includes(:user).where("id > ?", last_message_id)
   end
 end

--- a/app/views/api/messages/index.json.jbuilder
+++ b/app/views/api/messages/index.json.jbuilder
@@ -1,0 +1,7 @@
+json.array! @messages do |message|
+  json.member message.user.name
+  json.timestamp message.created_at.strftime("%Y年%m月%d日 %H時%M分")
+  json.content message.content
+  json.image message.image.url
+  json.id message.id
+end

--- a/app/views/messages/_message.html.haml
+++ b/app/views/messages/_message.html.haml
@@ -1,4 +1,4 @@
-.message-items
+.message-items{data: {message: {id: message.id}}}
   .message-items__title
     .member
       = message.user.name

--- a/app/views/messages/create.json.jbuilder
+++ b/app/views/messages/create.json.jbuilder
@@ -2,4 +2,4 @@ json.member @message.user.name
 json.timestamp @message.created_at.strftime("%Y年%m月%d日 %H時%M分")
 json.content @message.content
 json.image @message.image_url
-json.id message.id
+json.id @message.id

--- a/app/views/messages/create.json.jbuilder
+++ b/app/views/messages/create.json.jbuilder
@@ -2,3 +2,4 @@ json.member @message.user.name
 json.timestamp @message.created_at.strftime("%Y年%m月%d日 %H時%M分")
 json.content @message.content
 json.image @message.image_url
+json.id message.id

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,5 +4,8 @@ Rails.application.routes.draw do
   resources :users, only: [:index, :edit, :update]
   resources :groups, only: [:new, :create, :edit, :update] do
     resources :messages, only: [:index, :create]
+    namespace :api do
+      resources :messages, only: :index, defaults: { format: 'json' }
+    end
   end
 end


### PR DESCRIPTION
# What
Chat-spaceのメッセージ一覧画面において、自動更新機能を追加した。
・JQueryにて、７秒毎に「現在表示中のグループにおける最終メッセージIDを取得」し、API/messages#indexへデータを渡す
・message#indexでは、「表示中の最終メッセージID」と、DB上の最終メッセージのIDとを比較。差分のみを＠messagesとしてデータ取得。JSON形式データをビュー（jbuilder）へ渡す。
・ビューのJSONデータはJSファイルのdoneメソッドに送られて、メッセージ一覧画面に@messagesデータが反映される。

# Why
チャットツールにおいて、メッセージを都度手動でリロードするのは現実的ではなく、リアルタイムでの自動更新は必須の機能であるため。
![08978fa7153f368fe3eda986c05ae7ba](https://user-images.githubusercontent.com/63938372/82534777-b0a5da80-9b80-11ea-901a-f58791315ce4.gif)
